### PR TITLE
Feature/golang code generator (#47)

### DIFF
--- a/golang/pom.xml
+++ b/golang/pom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>parent</artifactId>
+        <groupId>com.regnosys.rosetta.code-generators</groupId>
+        <version>0.0.0.master</version>
+    </parent>
+
+    <properties>
+        <xtend.maven.plugin.version>2.15.0</xtend.maven.plugin.version>
+    </properties>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>golang</artifactId>
+	
+	<name>code-gen-golang</name>
+	
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.xtend</groupId>
+                <artifactId>xtend-maven-plugin</artifactId>
+                <version>${xtend.maven.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>Generate xtend sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.basedir}/target/main/generated/xtend</outputDirectory>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>Generate xtend test sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <testOutputDirectory>${project.basedir}/target/test/generated/xtend</testOutputDirectory>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+   		<dependency>
+			<groupId>com.regnosys.rosetta</groupId>
+			<artifactId>com.regnosys.rosetta.lib</artifactId>
+		</dependency>
+            <dependency>
+            <groupId>com.regnosys.rosetta</groupId>
+            <artifactId>com.regnosys.rosetta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.regnosys</groupId>
+            <artifactId>rosetta-common</artifactId>
+            <version>${regnosys.common.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.emf</groupId>
+            <artifactId>org.eclipse.emf.ecore</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.xtend</groupId>
+            <artifactId>org.eclipse.xtend.lib</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.xtext</groupId>
+            <artifactId>org.eclipse.xtext</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.regnosys.rosetta</groupId>
+            <artifactId>com.regnosys.rosetta.tests</artifactId>
+            <version>${rosetta.dsl.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.regnosys.rosetta.code-generators</groupId>
+            <artifactId>test-helper</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>            
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>java-hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/golang/src/main/java/com/regnosys/rosetta/generator/golang/GolangCodeGenerator.java
+++ b/golang/src/main/java/com/regnosys/rosetta/generator/golang/GolangCodeGenerator.java
@@ -1,0 +1,68 @@
+package com.regnosys.rosetta.generator.golang;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.google.inject.Inject;
+import com.regnosys.rosetta.generator.golang.enums.GolangEnumGenerator;
+import com.regnosys.rosetta.generator.golang.functions.GolangFunctionGenerator;
+import com.regnosys.rosetta.generator.golang.object.GolangModelObjectGenerator;
+import com.regnosys.rosetta.generator.external.AbstractExternalGenerator;
+import com.regnosys.rosetta.generator.java.RosettaJavaPackages;
+import com.regnosys.rosetta.rosetta.RosettaEnumeration;
+import com.regnosys.rosetta.rosetta.RosettaMetaType;
+import com.regnosys.rosetta.rosetta.RosettaModel;
+import com.regnosys.rosetta.rosetta.RosettaNamed;
+import com.regnosys.rosetta.rosetta.RosettaRootElement;
+import com.regnosys.rosetta.rosetta.simple.Data;
+import com.regnosys.rosetta.rosetta.simple.Function;
+
+public class GolangCodeGenerator extends AbstractExternalGenerator {
+
+	@Inject
+	GolangModelObjectGenerator pojoGenerator;
+	@Inject
+	private GolangEnumGenerator enumGenerator;
+	@Inject
+	private GolangFunctionGenerator functionGenerator;
+
+	public GolangCodeGenerator() {
+		super("Golang");
+		enumGenerator = new GolangEnumGenerator();
+	}
+
+	@Override
+	public Map<String, ? extends CharSequence> generate(RosettaJavaPackages packages, List<RosettaRootElement> elements,
+			String version) {
+		return Collections.emptyMap();
+	}
+	
+	@Override	
+	public Map<String, ? extends CharSequence> afterGenerate(Collection<? extends RosettaModel> models) {
+		String version = models.stream().map(m->m.getVersion()).findFirst().orElse("No version");
+		
+		Map<String, CharSequence> result = new HashMap<>();
+
+		List<Data> rosettaClasses = models.stream().flatMap(m->m.getElements().stream())
+				.filter((e)-> e instanceof Data)
+				.map(Data.class::cast).collect(Collectors.toList());
+		List<RosettaMetaType> metaTypes = models.stream().flatMap(m->m.getElements().stream()).filter(RosettaMetaType.class::isInstance)
+				.map(RosettaMetaType.class::cast).collect(Collectors.toList());
+
+		List<RosettaEnumeration> rosettaEnums = models.stream().flatMap(m->m.getElements().stream()).filter(RosettaEnumeration.class::isInstance)
+				.map(RosettaEnumeration.class::cast).collect(Collectors.toList());
+		
+		List<RosettaNamed> rosettaFunctions = models.stream().flatMap(m->m.getElements().stream()).filter(t -> Function.class.isInstance(t))
+				.map(RosettaNamed.class::cast).collect(Collectors.toList());
+
+		result.putAll(pojoGenerator.generate(rosettaClasses, metaTypes, version));
+		result.putAll(enumGenerator.generate(rosettaEnums, version));
+		result.putAll(functionGenerator.generate(rosettaFunctions, version));
+		return result;
+	}
+
+}

--- a/golang/src/main/java/com/regnosys/rosetta/generator/golang/enums/GolangEnumGenerator.xtend
+++ b/golang/src/main/java/com/regnosys/rosetta/generator/golang/enums/GolangEnumGenerator.xtend
@@ -1,0 +1,91 @@
+package com.regnosys.rosetta.generator.golang.enums
+
+import com.google.inject.Inject
+import com.regnosys.rosetta.generator.golang.object.GolangModelObjectBoilerPlate
+import com.regnosys.rosetta.rosetta.RosettaEnumValue
+import com.regnosys.rosetta.rosetta.RosettaEnumeration
+import java.util.ArrayList
+import java.util.HashMap
+import java.util.List
+import java.util.Map
+
+import static com.regnosys.rosetta.generator.golang.util.GolangModelGeneratorUtil.*
+import com.regnosys.rosetta.generator.java.enums.EnumHelper
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class GolangEnumGenerator {
+	
+	@Inject extension GolangModelObjectBoilerPlate
+	
+	static final String FILENAME = 'enums.go'
+	static final String FOLDERNAME = 'org_isda_cdm'
+		
+	
+	def Map<String, ? extends CharSequence>generate(Iterable<RosettaEnumeration> rosettaEnums, String version) {
+		val result = new HashMap
+		val enumTypes = rosettaEnums.sortBy[name].generateEnumTypes(version)
+		result.put(FOLDERNAME+"/"+FILENAME,enumTypes)
+		result.putAll(generateEnumVals(rosettaEnums.sortBy[name], version))
+		return result;
+		
+	}
+
+	def static toJavaEnumName(RosettaEnumeration enumeration, RosettaEnumValue rosettaEnumValue) {
+		return enumeration.name + '.' + EnumHelper.convertValues(rosettaEnumValue)
+	}
+
+	private def allEnumsValues(RosettaEnumeration enumeration) {
+		val enumValues = new ArrayList
+		var e = enumeration;
+
+		while (e !== null) {
+			e.enumValues.forEach[enumValues.add(it)]
+			e = e.superType
+		}
+		return enumValues.sortBy[name];
+	}
+
+	
+	private def generateEnumTypes(List<RosettaEnumeration> enums, String version){
+		return '''		
+		package org_isda_cdm
+		
+		«fileComment(version)»			
+		
+		«FOR e : enums»			
+			«classComment(e.definition)»
+			type «e.name» int			
+		«ENDFOR»
+	'''
+		
+	}
+	
+	private def generateEnumVals(List<RosettaEnumeration> enums, String version){
+		val dictionary = new HashMap<String, String>
+		for (e: enums){
+			val eString = '''		
+		«fileComment(version)»			
+			package «e.name»
+			import . "org_isda_cdm"
+			«val allEnumValues = allEnumsValues(e)»
+			«classComment(e.definition)»
+			
+			const (
+			«FOR value: allEnumValues»
+				«methodComment(value.definition)»
+				«EnumHelper.convertValues(value)» «e.name» = iota + 1
+			«ENDFOR»
+			)		
+		'''.replaceTabsWithSpaces
+		val enumName = FOLDERNAME+"/"+ e.name+"/"+e.name+".go"		
+		dictionary.put(enumName, eString)
+		}		
+		return dictionary		
+	}
+	
+	
+	def boolean anyValueHasSynonym(RosettaEnumeration enumeration) {
+		enumeration.allEnumsValues.map[enumSynonyms].flatten.size > 0
+	}
+}

--- a/golang/src/main/java/com/regnosys/rosetta/generator/golang/functions/GolangFunctionGenerator.xtend
+++ b/golang/src/main/java/com/regnosys/rosetta/generator/golang/functions/GolangFunctionGenerator.xtend
@@ -1,0 +1,104 @@
+package com.regnosys.rosetta.generator.golang.functions
+
+import com.regnosys.rosetta.generator.golang.object.GolangModelObjectBoilerPlate
+import com.regnosys.rosetta.rosetta.RosettaCardinality
+import com.regnosys.rosetta.rosetta.RosettaNamed
+import com.regnosys.rosetta.rosetta.simple.Attribute
+import com.regnosys.rosetta.rosetta.simple.Function
+import com.regnosys.rosetta.rosetta.simple.FunctionDispatch
+import java.util.HashMap
+import java.util.List
+import java.util.Map
+import javax.inject.Inject
+
+import static com.regnosys.rosetta.generator.golang.util.GolangModelGeneratorUtil.*
+
+import static extension com.regnosys.rosetta.generator.golang.util.GolangTranslator.toGOType
+
+class GolangFunctionGenerator {
+	@Inject extension GolangModelObjectBoilerPlate
+	
+	static final String FILENAME = 'functions.go'
+	static final String FOLDERNAME = 'org_isda_cdm_functions'
+		
+	def Map<String, ? extends CharSequence> generate(Iterable<RosettaNamed> rosettaFunctions, String version) {
+		val result = new HashMap
+		val functions = rosettaFunctions.sortBy[name].generateFunctions(version).replaceTabsWithSpaces
+		result.put(FOLDERNAME+"/"+ FILENAME,functions)
+		return result;
+	}
+	
+	private def generateFunctions(List<RosettaNamed> functions, String version)  '''
+		
+		«fileComment(version)»
+		package org_isda_cdm_functions	
+		
+		import "time"
+		import . "org_isda_cdm"		
+		
+		//Pointer type args used when the latter are optional
+		«FOR f : functions»
+			«writeFunction(f)»			
+		«ENDFOR»
+	'''
+	
+	private def dispatch writeFunction(RosettaNamed f)''''''
+	
+	private def dispatch writeFunction(Function f)
+	'''		
+		func «f.name.toFirstUpper»(«FOR input : f.inputs SEPARATOR ","»«input.name» «input.toType» «ENDFOR») «f.output.toType» {		
+		«classComment("Function definition for "+f.name)»			
+		return «f.output.toZeroValOfGoType»
+		}
+		
+	'''
+	
+	private def dispatch writeFunction(FunctionDispatch f)
+	''''''
+	
+	private def toZeroValOfGoType(Attribute att) {
+		switch att.toRawType.toString{
+			case "bool": '''false'''
+			case "int": '''0'''
+			case "float64": '''0'''			
+			default : '''«att.toReturnType»{}'''			
+		}
+			
+		
+	}
+	
+	private def toType(Attribute att) {
+		if (att.card!==null && att.card.sup>1)
+			'''[]«att.toRawType»'''
+		else
+			att.toRawType.prefixSingleOptional(att.card)
+	}
+	
+	private def toReturnType(Attribute att) {
+		if (att.card!==null && att.card.sup>1)
+			'''[]«att.toRawType»'''
+		else
+			att.toRawType.prefixSingleOptionalReturn(att.card)
+	}
+	
+	private def toRawType(Attribute input) {
+		input.type.name.toGOType	
+	}
+	
+	
+	//optional parameters are made into pointer types so that nil can be passed when the option is absent
+	//perhaps a better approach is to pass lists as is done in Java CDM
+	private def prefixSingleOptional(CharSequence type, RosettaCardinality card) {
+		if (card!==null && card.inf<1)
+			'''*«type»'''
+		else
+			type
+	}
+	
+	private def prefixSingleOptionalReturn(CharSequence type, RosettaCardinality card) {
+		if (card!==null && card.inf<1)
+			'''&«type»'''
+		else
+			type
+	}
+}

--- a/golang/src/main/java/com/regnosys/rosetta/generator/golang/object/GolangMetaFieldGenerator.xtend
+++ b/golang/src/main/java/com/regnosys/rosetta/generator/golang/object/GolangMetaFieldGenerator.xtend
@@ -1,0 +1,42 @@
+package com.regnosys.rosetta.generator.golang.object
+
+import com.regnosys.rosetta.rosetta.RosettaMetaType
+
+import static com.regnosys.rosetta.generator.golang.util.GolangModelGeneratorUtil.*
+
+import static extension com.regnosys.rosetta.generator.util.Util.*
+import static extension com.regnosys.rosetta.generator.golang.util.GolangTranslator.toGOType
+
+class GolangMetaFieldGenerator {
+	
+	def generateMetaFields(Iterable<RosettaMetaType> metaTypes, String version) {
+		fileComment(version) + metaClasses.toString + metaFields(metaTypes.filter[name !== "reference"], version)
+	}
+	
+		private def metaClasses() '''
+		package org_isda_cdm_metafields
+		
+		type FieldWithMeta struct {
+		  Value interface{};
+		  Meta MetaFields;
+		}
+
+		type ReferenceWithMeta struct {
+		  GlobalReference string;
+		  ExternalReference string;
+		  Value interface{};
+		}
+				
+	'''
+	
+	def metaFields(Iterable<RosettaMetaType> types, String version) '''				
+		type MetaFields struct {
+			«FOR type : types.distinctBy(t|t.name.toFirstLower)»
+				«type.name.toFirstUpper» «type.type.name.toGOType»;
+			«ENDFOR»
+			GlobalKey string;
+			ExternalKey string;
+		}
+		
+	'''
+}

--- a/golang/src/main/java/com/regnosys/rosetta/generator/golang/object/GolangModelObjectBoilerPlate.xtend
+++ b/golang/src/main/java/com/regnosys/rosetta/generator/golang/object/GolangModelObjectBoilerPlate.xtend
@@ -1,0 +1,48 @@
+package com.regnosys.rosetta.generator.golang.object
+
+import com.regnosys.rosetta.generator.object.ExpandedAttribute
+
+import static extension com.regnosys.rosetta.generator.golang.util.GolangTranslator.toGOType
+
+class GolangModelObjectBoilerPlate {
+		
+	def toAttributeName(ExpandedAttribute attribute) {
+		if (attribute.name == "type")
+			'''_type'''
+		else
+			attribute.name.toFirstUpper
+	}
+	
+	def replaceTabsWithSpaces(CharSequence code) {
+		code.toString.replace('\t', '  ')
+	}
+	
+	def toType(ExpandedAttribute attribute) 
+		'''«IF attribute.isMultiple»[]«ENDIF»«attribute.toRawType»'''
+	
+	private def toRawType(ExpandedAttribute attribute) {
+		if (!attribute.hasMetas) 
+			attribute.type.name.toGOType
+		else if (attribute.refIndex >= 0) {
+			if (attribute.type.isType)
+				attribute.type.name.toReferenceWithMetaTypeName
+			else 
+				attribute.type.name.toBasicReferenceWithMetaTypeName
+		}
+		else 
+			attribute.type.name.toFieldWithMetaTypeName
+	}
+	
+		
+	private def toReferenceWithMetaTypeName(String type) {
+		'''ReferenceWithMeta'''
+	}
+	
+	private def toBasicReferenceWithMetaTypeName(String type) {
+		'''ReferenceWithMeta'''
+	}
+	
+	private def toFieldWithMetaTypeName(String type) {
+		'''FieldWithMeta'''
+	}
+}

--- a/golang/src/main/java/com/regnosys/rosetta/generator/golang/object/GolangModelObjectGenerator.xtend
+++ b/golang/src/main/java/com/regnosys/rosetta/generator/golang/object/GolangModelObjectGenerator.xtend
@@ -1,0 +1,90 @@
+package com.regnosys.rosetta.generator.golang.object
+
+import com.google.inject.Inject
+import com.regnosys.rosetta.RosettaExtensions
+import com.regnosys.rosetta.rosetta.RosettaClass
+import com.regnosys.rosetta.rosetta.RosettaMetaType
+import java.util.List
+
+import static com.regnosys.rosetta.generator.golang.util.GolangModelGeneratorUtil.*
+
+import static extension com.regnosys.rosetta.generator.util.RosettaAttributeExtensions.*
+import java.util.Map
+import java.util.HashMap
+import com.regnosys.rosetta.rosetta.simple.Data
+import com.regnosys.rosetta.generator.object.ExpandedAttribute
+import java.util.Set
+import com.google.common.collect.Lists
+
+class GolangModelObjectGenerator {
+
+	@Inject extension RosettaExtensions
+	@Inject extension GolangModelObjectBoilerPlate
+	@Inject extension GolangMetaFieldGenerator
+	
+	static final String CLASSES_FILENAME = 'types.go'
+	static final String META_FILENAME = 'metatypes.go'
+	static final String CLASSES_FOLDERNAME = 'org_isda_cdm'
+	static final String META_FOLDERNAME = 'org_isda_cdm_metafields'
+	
+	def Map<String, ? extends CharSequence> generate(Iterable<Data> rosettaClasses, Iterable<RosettaMetaType> metaTypes, String version) {
+		val result = new HashMap		
+		val enumImports = rosettaClasses
+				.map[allExpandedAttributes].flatten
+				.map[type]
+				.filter[isEnumeration]
+				.map[name]
+				.toSet
+		
+		val classes = rosettaClasses.sortBy[name].generateClasses(enumImports, version).replaceTabsWithSpaces
+		result.put(CLASSES_FOLDERNAME+"/"+ CLASSES_FILENAME, classes)
+		val metaFields = generateMetaFields(metaTypes, version).replaceTabsWithSpaces
+		result.put(META_FOLDERNAME +"/"+ META_FILENAME, metaFields)
+		result;
+	}
+	
+	
+	private def generateClasses(List<Data> rosettaClasses, Set<String> importedEnums,  String version) {
+	'''	
+	package org_isda_cdm
+	
+	«fileComment(version)»	
+	
+	import "time"
+	import . "org_isda_cdm_metafields";
+		
+	
+	«FOR c : rosettaClasses»
+		«classComment(c.definition)»
+		type «c.name» struct {
+			«FOR attribute : c.allExpandedAttributes»				
+				«methodComment(attribute.definition)»
+				«IF (c.name.toString == "Pric" && attribute.toType.toString == "Pric") || (c.name.toString == "New" && attribute.toType.toString == "Tx")»
+				«attribute.toAttributeName» *«attribute.toType»;
+				«ELSE»
+				«attribute.toAttributeName» «attribute.toType»;
+				«ENDIF»
+			«ENDFOR»
+		}
+			
+	«ENDFOR»
+	'''}
+	
+	
+	
+	def dispatch Iterable<ExpandedAttribute> allExpandedAttributes(RosettaClass type) {
+		type.allSuperTypes.expandedAttributes
+	}
+	
+	def dispatch Iterable<ExpandedAttribute> allExpandedAttributes(Data type){
+		type.allSuperTypes.map[it.expandedAttributes].flatten
+	}
+	
+	def dispatch String definition(RosettaClass element) {
+		element.definition
+	}
+	def dispatch String definition(Data element){
+		element.definition
+	}
+
+}

--- a/golang/src/main/java/com/regnosys/rosetta/generator/golang/util/GolangModelGeneratorUtil.xtend
+++ b/golang/src/main/java/com/regnosys/rosetta/generator/golang/util/GolangModelGeneratorUtil.xtend
@@ -1,0 +1,28 @@
+package com.regnosys.rosetta.generator.golang.util
+
+class GolangModelGeneratorUtil {
+	
+	static def fileComment(String version) '''
+			/**
+			 * This file is auto-generated from the ISDA Common Domain Model, do not edit.
+			 * Version: «version»
+			 */
+	'''
+		
+	static def classComment(String definition) {
+		comment(definition)
+	}
+	
+	static def methodComment(String definition) {
+		comment(definition)
+	}
+	
+	private static def comment(String definition) '''
+		«IF definition !==null && !definition.isEmpty »
+			/**
+			 * «definition»
+			 */
+		«ENDIF»
+	'''
+	
+}

--- a/golang/src/main/java/com/regnosys/rosetta/generator/golang/util/GolangTranslator.xtend
+++ b/golang/src/main/java/com/regnosys/rosetta/generator/golang/util/GolangTranslator.xtend
@@ -1,0 +1,43 @@
+package com.regnosys.rosetta.generator.golang.util
+
+import com.regnosys.rosetta.types.RCalculationType
+import com.regnosys.rosetta.types.RQualifiedType
+
+class GolangTranslator {
+				
+	static def toGOBasicType(String typename) {
+		switch typename {
+			case 'String',				
+			case 'string':
+				'string'								 			
+			case 'int':
+				'int'
+			case 'time':
+				'time.Time'
+			case 'date':
+				'time.Time'
+			case 'Date':
+				'time.Time'
+			case 'zonedDateTime':
+				'time.Time'
+			case 'number':
+				'float64'
+			case 'boolean':
+				'bool'
+			case RQualifiedType.PRODUCT_TYPE.qualifiedType:
+				'string'
+			case RQualifiedType.EVENT_TYPE.qualifiedType:
+				'string'
+			case RCalculationType.CALCULATION.calculationType:
+				'string'
+		}
+	}
+
+	static def toGOType(String typename) {
+		val basicType = com.regnosys.rosetta.generator.golang.util.GolangTranslator.toGOBasicType(typename);
+		if (basicType !== null)
+			return basicType
+		else
+			return typename
+	}
+}

--- a/golang/src/test/java/com/regnosys/rosetta/generator/golang/GolangModelObjectGeneratorTest.xtend
+++ b/golang/src/test/java/com/regnosys/rosetta/generator/golang/GolangModelObjectGeneratorTest.xtend
@@ -1,0 +1,219 @@
+package com.regnosys.rosetta.generator.golang
+
+import com.google.inject.Inject
+import com.regnosys.rosetta.rosetta.RosettaModel
+import com.regnosys.rosetta.tests.RosettaInjectorProvider
+import com.regnosys.rosetta.tests.util.ModelHelper
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.extensions.InjectionExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.^extension.ExtendWith
+
+import static org.junit.jupiter.api.Assertions.*
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.io.File
+import org.eclipse.xtext.testing.util.ParseHelper
+import org.eclipse.xtext.resource.XtextResourceSet
+import com.google.inject.Provider
+import org.eclipse.lsp4j.generator.TypeAdapterImpl
+import org.junit.jupiter.api.Disabled
+import java.io.IOException
+
+//import org.junit.jupiter.api.Disabled
+
+/**
+ * The parser of rosetta files has a particular requirement:
+ * namespace declaration should not have any comments,
+ * so all text ":<...>" should be removed from the namespace line
+ * if present.
+ */
+@ExtendWith(InjectionExtension)
+@InjectWith(RosettaInjectorProvider)
+class GolangModelObjectGeneratorTest {
+
+	@Inject extension ModelHelper
+	@Inject GolangCodeGenerator generator;
+
+	@Inject extension ParseHelper<RosettaModel>
+	@Inject Provider<XtextResourceSet> resourceSetProvider;
+
+	@Test
+	@Disabled("Test to generate the golang for CDM")
+	def void generateCdm() {
+
+		val dirs = newArrayList(			
+			('rosetta-cdm/src/main/rosetta'),
+			('rosetta-dsl/com.regnosys.rosetta.lib/src/main/java/model')
+		);
+
+		val resourceSet = resourceSetProvider.get	
+
+		dirs.map[new File(it)].map[listFiles[it.name.endsWith('.rosetta')]].flatMap [
+			map[Files.readAllBytes(toPath)].map[new String(it)]
+		].forEach[parse(resourceSet)]
+
+		val rosettaModels = resourceSet.resources.map[contents.filter(RosettaModel)].flatten.toList
+
+		val generatedFiles = generator.afterGenerate(rosettaModels)		
+
+		val rootDir = System.getProperty("user.dir")
+		
+		generatedFiles.forEach [ fileName, contents |{
+			val pathString = rootDir+"/"+fileName
+			val path = Paths.get(pathString)
+			val file = new File(pathString);
+			file.getParentFile().mkdirs();					
+			Files.write(path, contents.toString.bytes)			
+		}
+			
+		]
+	}
+
+	@Test
+	def void shouldGenerateEnums() {
+		val golang = '''
+			enum TestEnum: <"Test enum description.">
+				TestEnumValue1 <"Test enum value 1">
+				TestEnumValue2 <"Test enum value 2">
+		'''.generateGolang
+		 
+    	val enumString = golang.get('org_isda_cdm/TestEnum/TestEnum.go').toString; 
+     	
+		assertTrue(enumString.contains('''
+		/**
+		 * This file is auto-generated from the ISDA Common Domain Model, do not edit.
+		 * Version: test
+		 */
+		  package TestEnum
+		  import . "org_isda_cdm"
+		  /**
+		   * Test enum description.
+		   */
+		  
+		  const (
+		  /**
+		   * Test enum value 1
+		   */
+		  TEST_ENUM_VALUE_1 TestEnum = iota + 1
+		  /**
+		   * Test enum value 2
+		   */
+		  TEST_ENUM_VALUE_2 TestEnum = iota + 1
+		  )    ''')
+		  )
+	}
+
+	@Test
+	def void shouldGenerateTypes() {
+		val golang = '''
+			type TestType: <"Test type description.">
+				TestTypeValue1 string(1..1) <"Test string">
+				TestTypeValue2 string(0..1) <"Test optional string">
+				TestTypeValue3 string(0..*) <"Test string list">
+				TestTypeValue4 TestType2(1..1) <"Test TestType2">
+				
+			type TestType2:
+				TestType2Value1 number(1..1) <"Test number">
+				TestType2Value2 date(1..1) <"Test date">
+		'''.generateGolang
+
+		val types = golang.get('org_isda_cdm/types.go').toString
+		
+		assertTrue(types.contains('''
+		package org_isda_cdm
+		
+		/**
+		 * This file is auto-generated from the ISDA Common Domain Model, do not edit.
+		 * Version: test
+		 */
+		
+		import "time"
+		import . "org_isda_cdm_metafields";
+		  
+		
+		/**
+		 * Test type description.
+		 */
+		type TestType struct {
+		  /**
+		   * Test string
+		   */
+		  TestTypeValue1 string;
+		  /**
+		   * Test optional string
+		   */
+		  TestTypeValue2 string;
+		  /**
+		   * Test string list
+		   */
+		  TestTypeValue3 []string;
+		  /**
+		   * Test TestType2
+		   */
+		  TestTypeValue4 TestType2;
+		}
+		  
+		type TestType2 struct {
+		  /**
+		   * Test number
+		   */
+		  TestType2Value1 float64;
+		  /**
+		   * Test date
+		   */
+		  TestType2Value2 time.Time;
+		}'''))
+
+	}	
+	
+	
+	@Test	
+	def void shouldGenerateMetaTypes() {
+		val golang = '''
+			metaType reference string
+			metaType scheme string
+			metaType id string
+			
+			type TestType:
+				[metadata key]
+				TestTypeValue1 TestType2(1..1)
+					[metadata reference]
+			
+			type TestType2:
+				TestType2Value1 number(1..1)
+					[metadata reference]
+					
+				TestType2Value2 string(1..1)
+					[metadata id]
+					[metadata scheme]
+							'''.generateGolang
+
+		val types = golang.values.join('\n').toString
+				
+		assertTrue(types.contains('''
+		type FieldWithMeta struct {
+		  Value interface{};
+		  Meta MetaFields;
+		}'''))
+
+		assertTrue(types.contains('''
+		type TestType struct {
+		  TestTypeValue1 ReferenceWithMeta;
+		  Meta MetaFields;
+		}'''))
+
+		assertTrue(types.contains('''
+		type TestType2 struct {
+		  TestType2Value1 ReferenceWithMeta;
+		  TestType2Value2 FieldWithMeta;
+		}'''))
+
+	}
+
+	def generateGolang(CharSequence model) {
+		val eResource = model.parseRosettaWithNoErrors.eResource
+
+		generator.afterGenerate(eResource.contents.filter(RosettaModel).toList)
+	}
+}

--- a/golang/src/test/resources/rosetta/sample.rosetta
+++ b/golang/src/test/resources/rosetta/sample.rosetta
@@ -1,0 +1,22 @@
+namespace "com.rosetta.model"
+version "test"
+
+type Foo:<"A sample class">
+    stringAttribute string (1..1)
+    intAttribute int (1..1)
+    dataAttribute DataFoo (1..1)
+    multipleAttribute string (1..*)
+
+type DataFoo: <"A sample data">
+	stringAttribute string (1..1)
+    intAttribute int (1..1)
+    multipleAttribute Foo (1..*)
+    
+enum Bar: <"Specifies delivery methods for securities transactions. This coding-scheme defines the possible delivery methods for securities.">
+	AA 
+	BB 
+	CC 
+
+func DoStuff: 
+	inputs: foo Foo(1..1)
+	output: bar Bar (1..1)

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
 		<module>default-cdm-generators</module>
 		<module>typescript</module>
 		<module>scala</module>
+		<module>golang</module>
 	</modules>
 
 	<dependencyManagement>


### PR DESCRIPTION
* changed back dirs for rosetta files in golang to the default ones

* final version of go code generaot to incorporate into rosetta-code-generators

* unit tests GolangModelObjectGeneratorTest.shouldGenerateEnums and GolangModelObjectGeneratorTest.shouldGenerateTypes are fixed

* final fix of unit test GolangModelObjectGeneratorTest.shouldGenerateEnums

* enabled unit test for metaTypes

* removed unused generate and generateEnums functions

* cosmetic changes/clean ups

* packages names changed

* removed the side-effects of writing files in generateEnums()

* removed the parent folder cdm

* disabled generateCDM test

* added module golang to the list of modules in the parent pom file

* modified the generated filenames to include folder names

* modified golang pom file to allign with recent changes in the master branch

* changed custom golang types to standard float64 and time in the rosetta to golang type names dictionary; correspondingly changed import statements

Co-authored-by: denbash <dbashkirov@fairom.com>